### PR TITLE
Using "extended_entities" instead of "entities" for media

### DIFF
--- a/tweetjs-to-mastodon.ipynb
+++ b/tweetjs-to-mastodon.ipynb
@@ -258,7 +258,7 @@
     "        if 'media' in tweet['entities']:\n",
     "            # upload media to append to the post\n",
     "            media_ids = []\n",
-    "            for media in tweet['entities']['media']:\n",
+    "            for media in tweet['extended_entities']['media']:\n",
     "                image_path = f\"{media_dir}{tweet['id']}-{media['media_url_https'].split('/')[-1]}\"\n",
     "                if not Path(image_path).is_file():\n",
     "                    image_path = f\"{media_dir_backup}{tweet['id']}-{media['media_url_https'].split('/')[-1]}\"\n",


### PR DESCRIPTION
When running the script, I noticed tweets that had multiple images only had one image after being imported to Mastodon.

After investigating, it looks like tweets with multiple images store those images inside of `extended_entities`. Only one image is stored in `entities`.